### PR TITLE
Fix OG site name

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="../index.html@p=8.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="en_GB" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="About Us – Innoledge" />
 		<meta property="og:description" content="Bruno LERAILLEZ Dr. Bruno Leraillez launched INNOLEDGE INTERNATIONAL LTD., a creative venture backed by inside knowledge and corporate experience in Asia gained over 20 years.The expertise comes from assignments that were mainly operational in Japan, where he was in charge of Northeast Asian countries, and later in Hong Kong and China, where his mission was" />

--- a/contact-us/index.html
+++ b/contact-us/index.html
@@ -13,7 +13,7 @@
 		<link rel="canonical" href="../index.html@p=9.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="en_GB" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Contact Us – Innoledge" />
 		<meta property="og:url" content="https://innoledge.com/contact-us/" />

--- a/fr/contactez-nous/index.html
+++ b/fr/contactez-nous/index.html
@@ -13,7 +13,7 @@
 		<link rel="canonical" href="../../index.html@p=252.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="fr_FR" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Contactez-Nous – Innoledge" />
 		<meta property="og:url" content="https://innoledge.com/fr/contactez-nous/" />

--- a/fr/page-daccueil/index.html
+++ b/fr/page-daccueil/index.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="index.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="fr_FR" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Page d’accueil – Innoledge" />
 		<meta property="og:description" content="Marketing Sourcing Investissement Affaires Réglementaires Business Consultant Distribution Notre Société INNOLEDGE INTERNATIONAL LTD. est un réseau multiculturel de professionnels avec plus de 30 ans d&#039;expérience dans le commerce et les investissements en Asie, avec une expertise particulière dans les industries de la santé, des cosmétiques et de l’ agro-alimentaire. Rejoignez le réseau INNOLEDGE INTERNATIONAL et vous" />

--- a/fr/portfolio/index.html
+++ b/fr/portfolio/index.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="../../index.html@p=197.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="fr_FR" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Portfolio – Innoledge" />
 		<meta property="og:description" content="NOTRE PORTEFEUILLE Les produits que nous proposons en Asie proviennent principalement de fournisseurs basés en Europe (Scandinavie, Royaume-Uni, Allemagne, Belgique, France, Espagne, Italie et Suisse) et le Japon. Médicaments Antibiotiques: quinolonesOphtalmologie: MyopieGastro-entérologie: probiotiquesPersonnes âgées: ostéoporose, hormonesOncologie: RadiothérapieChirurgie Esthétique: Hyaluronic AcidDermatologie: cicatrisation des plaiesChirurgie: cicatrisation des plaieshépatologie: cholagogues et cholérétiquesGynécologie: hygiène féminine, HormonesCardiologie: régulateur des lipidesPédiatrie:" />

--- a/fr/qui-sommes-nous/index.html
+++ b/fr/qui-sommes-nous/index.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="../../index.html@p=192.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="fr_FR" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Qui Sommes-Nous – Innoledge" />
 		<meta property="og:description" content="Bruno LERAILLEZ INNOLEDGE International Ltd., a eté créé par le Dr. Bruno LERAILLEZ sur la base de sa connaissance intime et de l&#039; expérience professionnelle aquises pendant plus de vingt ans en Asie.Son expérience est le fruit de responsabilités assumées surtout dans des postes opérationnels au Japon, où il a été responsable de la région" />

--- a/fr/service.html
+++ b/fr/service.html
@@ -13,7 +13,7 @@
 		<link rel="canonical" href="service.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="fr_FR" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="website" />
 		<meta property="og:title" content="Services – Innoledge" />
 		<meta property="og:url" content="https://innoledge.com/fr/service/" />

--- a/fr/services/affaires-reglementaires/index.html
+++ b/fr/services/affaires-reglementaires/index.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="../../../index.html@p=230.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="fr_FR" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Affaires Réglementaires – Innoledge" />
 		<meta property="og:description" content="Les besoins d’enregistrements et de licences peuvent être considérés comme obstacles laborieux et perte de temps mais c&#039;est aussi une protection utile des investissements dans vos projets." />

--- a/fr/services/business-consultant/index.html
+++ b/fr/services/business-consultant/index.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="../../../index.html@p=236.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="fr_FR" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Business Consultant – Innoledge" />
 		<meta property="og:description" content="Des solutions à vos problèmes, «tous problème». C&#039;est le service qu’INNOLEDGE INTERNATIONAL offre à ces clients, aux investisseurs, partenaires de joint-venture et aux entreprises qui débutent en Asie ou y sont déjà installées." />

--- a/fr/services/distribution-2/index.html
+++ b/fr/services/distribution-2/index.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="../../../index.html@p=239.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="fr_FR" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Distribution – Innoledge" />
 		<meta property="og:description" content="En raison de la réglementation relativement simple à Hong Kong concernant les importations de médicaments et de cosmétiques, INNOLEDGE INTERNATIONAL fournit des distributeurs locaux et les utilisateurs directs. INNOLEDGE INTERNATIONAL utilise aussi Hong Kong comme hub et réexporte vers la Chine et les autres pays d’Asie." />

--- a/fr/services/france-marketing/index.html
+++ b/fr/services/france-marketing/index.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="../../../index.html@p=212.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="fr_FR" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Marketing – Innoledge" />
 		<meta property="og:description" content="Nous allons vous aider à développer votre entreprise grâce à une approche marketing intégrée. Nous savons l&#039;importance de construire un programme complet de marketing - nous allons le traduire en chiffre d&#039;affaires, nous ferons le travail pour vous." />

--- a/fr/services/investissement/index.html
+++ b/fr/services/investissement/index.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="../../../index.html@p=224.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="fr_FR" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Investissement – Innoledge" />
 		<meta property="og:description" content="Trouver les opportunités d&#039;investissement les plus prometteuses pour lancer la dynamique de votre projet . Démarrez votre réussite dès aujourd&#039;hui." />

--- a/fr/services/sourcing-2/index.html
+++ b/fr/services/sourcing-2/index.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="../../../index.html@p=219.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="fr_FR" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Sourcing – Innoledge" />
 		<meta property="og:description" content="Le sourcing est une activité vitale, nous avons l’expérience de sourcing pour de nombreuses sociétés dans de nombreux pays - nous pouvons vous aider dans ces diverses tâches." />

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="index.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="en_GB" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="website" />
 		<meta property="og:title" content="Homepage – Innoledge" />
 		<meta property="og:description" content="Marketing Sourcing Investment Regulatory Affairs Business Consultancy Distribution OUR COMPANY INNOLEDGE INTERNATIONAL LTD. is a multicultural network of professionals with over 30 years of experience in trade and investments in Asia, with special emphasis on Health, Cosmetics and Agro-Food business. Lock into the INNOLEDGE INTERNATIONAL network and you are assured instant access to market surveys and" />

--- a/index.html@p=192.html
+++ b/index.html@p=192.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="index.html@p=192.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="fr_FR" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Qui Sommes-Nous – Innoledge" />
 		<meta property="og:description" content="Bruno LERAILLEZ INNOLEDGE International Ltd., a eté créé par le Dr. Bruno LERAILLEZ sur la base de sa connaissance intime et de l&#039; expérience professionnelle aquises pendant plus de vingt ans en Asie.Son expérience est le fruit de responsabilités assumées surtout dans des postes opérationnels au Japon, où il a été responsable de la région" />

--- a/index.html@p=197.html
+++ b/index.html@p=197.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="index.html@p=197.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="fr_FR" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Portfolio – Innoledge" />
 		<meta property="og:description" content="NOTRE PORTEFEUILLE Les produits que nous proposons en Asie proviennent principalement de fournisseurs basés en Europe (Scandinavie, Royaume-Uni, Allemagne, Belgique, France, Espagne, Italie et Suisse) et le Japon. Médicaments Antibiotiques: quinolonesOphtalmologie: MyopieGastro-entérologie: probiotiquesPersonnes âgées: ostéoporose, hormonesOncologie: RadiothérapieChirurgie Esthétique: Hyaluronic AcidDermatologie: cicatrisation des plaiesChirurgie: cicatrisation des plaieshépatologie: cholagogues et cholérétiquesGynécologie: hygiène féminine, HormonesCardiologie: régulateur des lipidesPédiatrie:" />

--- a/index.html@p=212.html
+++ b/index.html@p=212.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="index.html@p=212.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="fr_FR" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Marketing – Innoledge" />
 		<meta property="og:description" content="Nous allons vous aider à développer votre entreprise grâce à une approche marketing intégrée. Nous savons l&#039;importance de construire un programme complet de marketing - nous allons le traduire en chiffre d&#039;affaires, nous ferons le travail pour vous." />

--- a/index.html@p=219.html
+++ b/index.html@p=219.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="index.html@p=219.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="fr_FR" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Sourcing – Innoledge" />
 		<meta property="og:description" content="Le sourcing est une activité vitale, nous avons l’expérience de sourcing pour de nombreuses sociétés dans de nombreux pays - nous pouvons vous aider dans ces diverses tâches." />

--- a/index.html@p=224.html
+++ b/index.html@p=224.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="index.html@p=224.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="fr_FR" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Investissement – Innoledge" />
 		<meta property="og:description" content="Trouver les opportunités d&#039;investissement les plus prometteuses pour lancer la dynamique de votre projet . Démarrez votre réussite dès aujourd&#039;hui." />

--- a/index.html@p=230.html
+++ b/index.html@p=230.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="index.html@p=230.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="fr_FR" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Affaires Réglementaires – Innoledge" />
 		<meta property="og:description" content="Les besoins d’enregistrements et de licences peuvent être considérés comme obstacles laborieux et perte de temps mais c&#039;est aussi une protection utile des investissements dans vos projets." />

--- a/index.html@p=236.html
+++ b/index.html@p=236.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="index.html@p=236.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="fr_FR" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Business Consultant – Innoledge" />
 		<meta property="og:description" content="Des solutions à vos problèmes, «tous problème». C&#039;est le service qu’INNOLEDGE INTERNATIONAL offre à ces clients, aux investisseurs, partenaires de joint-venture et aux entreprises qui débutent en Asie ou y sont déjà installées." />

--- a/index.html@p=239.html
+++ b/index.html@p=239.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="index.html@p=239.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="fr_FR" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Distribution – Innoledge" />
 		<meta property="og:description" content="En raison de la réglementation relativement simple à Hong Kong concernant les importations de médicaments et de cosmétiques, INNOLEDGE INTERNATIONAL fournit des distributeurs locaux et les utilisateurs directs. INNOLEDGE INTERNATIONAL utilise aussi Hong Kong comme hub et réexporte vers la Chine et les autres pays d’Asie." />

--- a/index.html@p=252.html
+++ b/index.html@p=252.html
@@ -13,7 +13,7 @@
 		<link rel="canonical" href="index.html@p=252.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="fr_FR" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Contactez-Nous – Innoledge" />
 		<meta property="og:url" content="https://innoledge.com/fr/contactez-nous/" />

--- a/index.html@p=52.html
+++ b/index.html@p=52.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="index.html@p=52.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="en_GB" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Our Portfolio – Innoledge" />
 		<meta property="og:description" content="OUR PORTFOLIO The products that we propose in Asia mainly come from suppliers based in Europe (Scandinavia, UK, Germany, Belgium, France, Spain, Italy and Switzerland) and Japan. They consist of: Medicines Antibiotics: QuinoloneOphtalmology: MyopiaGastro-Enterology: ProbioticsGeriatrics: Osteoporosis, HormonesOncology: RadiotherapyEsthetic surgery: Hyaluronic AcidsDermatology: Derma Therapy Wound HealingSurgery: Wound healingHepatology: Cholagogues and CholereticsGynecology: Feminine Hygiene, HormonesCardiology: Lipid RegulatorPediatrics:" />

--- a/index.html@p=62.html
+++ b/index.html@p=62.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="index.html@p=62.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="en_GB" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Marketing – Innoledge" />
 		<meta property="og:description" content="Sourcing is an in demand business, we have sourced products for many companies in many countries – we can assist you with various tasks." />

--- a/index.html@p=63.html
+++ b/index.html@p=63.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="index.html@p=63.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="en_GB" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Sourcing – Innoledge" />
 		<meta property="og:description" content="Sourcing is an in demand business, we have sourced products for many companies in many countries – we can assist you with various tasks." />

--- a/index.html@p=64.html
+++ b/index.html@p=64.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="index.html@p=64.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="en_GB" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Investment – Innoledge" />
 		<meta property="og:description" content="Find the most promising investment opportunities to launch your dynamic vision. Jumpstart your success today." />

--- a/index.html@p=65.html
+++ b/index.html@p=65.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="index.html@p=65.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="en_GB" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Regulatory Affairs – Innoledge" />
 		<meta property="og:description" content="The needs of registrations and licenses can be seen as laborious and time consuming hurdles but it is also a useful protection to invest in business development." />

--- a/index.html@p=66.html
+++ b/index.html@p=66.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="index.html@p=66.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="en_GB" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Business Consultancy – Innoledge" />
 		<meta property="og:description" content="SOLUTIONS TO PROBLEMS, &quot;ANY PROBLEMS&quot;. This is the service INNOLEDGE INTERNATIONAL offers investors, joint-venture partners and entrepreneurs for developing business in Asia and with Asia." />

--- a/index.html@p=67.html
+++ b/index.html@p=67.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="index.html@p=67.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="en_GB" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Distribution – Innoledge" />
 		<meta property="og:description" content="Hong Kong: Because of the relatively simple regulation concerning imports in Hong Kong of Medicines and Cosmetics, INNOLEDGE INTERNATIONAL supplies local distributors and direct users." />

--- a/index.html@p=8.html
+++ b/index.html@p=8.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="index.html@p=8.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="en_GB" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="About Us – Innoledge" />
 		<meta property="og:description" content="Bruno LERAILLEZ Dr. Bruno Leraillez launched INNOLEDGE INTERNATIONAL LTD., a creative venture backed by inside knowledge and corporate experience in Asia gained over 20 years.The expertise comes from assignments that were mainly operational in Japan, where he was in charge of Northeast Asian countries, and later in Hong Kong and China, where his mission was" />

--- a/index.html@p=9.html
+++ b/index.html@p=9.html
@@ -13,7 +13,7 @@
 		<link rel="canonical" href="index.html@p=9.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="en_GB" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Contact Us – Innoledge" />
 		<meta property="og:url" content="https://innoledge.com/contact-us/" />

--- a/our-portfolio/index.html
+++ b/our-portfolio/index.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="../index.html@p=52.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="en_GB" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Our Portfolio – Innoledge" />
 		<meta property="og:description" content="OUR PORTFOLIO The products that we propose in Asia mainly come from suppliers based in Europe (Scandinavia, UK, Germany, Belgium, France, Spain, Italy and Switzerland) and Japan. They consist of: Medicines Antibiotics: QuinoloneOphtalmology: MyopiaGastro-Enterology: ProbioticsGeriatrics: Osteoporosis, HormonesOncology: RadiotherapyEsthetic surgery: Hyaluronic AcidsDermatology: Derma Therapy Wound HealingSurgery: Wound healingHepatology: Cholagogues and CholereticsGynecology: Feminine Hygiene, HormonesCardiology: Lipid RegulatorPediatrics:" />

--- a/service.html
+++ b/service.html
@@ -13,7 +13,7 @@
 		<link rel="canonical" href="service.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="en_GB" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="website" />
 		<meta property="og:title" content="Services – Innoledge" />
 		<meta property="og:url" content="https://innoledge.com/service/" />

--- a/services/business-consultancy/index.html
+++ b/services/business-consultancy/index.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="../../index.html@p=66.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="en_GB" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Business Consultancy – Innoledge" />
 		<meta property="og:description" content="SOLUTIONS TO PROBLEMS, &quot;ANY PROBLEMS&quot;. This is the service INNOLEDGE INTERNATIONAL offers investors, joint-venture partners and entrepreneurs for developing business in Asia and with Asia." />

--- a/services/distribution/index.html
+++ b/services/distribution/index.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="../../index.html@p=67.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="en_GB" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Distribution – Innoledge" />
 		<meta property="og:description" content="Hong Kong: Because of the relatively simple regulation concerning imports in Hong Kong of Medicines and Cosmetics, INNOLEDGE INTERNATIONAL supplies local distributors and direct users." />

--- a/services/investment/index.html
+++ b/services/investment/index.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="../../index.html@p=64.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="en_GB" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Investment – Innoledge" />
 		<meta property="og:description" content="Find the most promising investment opportunities to launch your dynamic vision. Jumpstart your success today." />

--- a/services/marketing/index.html
+++ b/services/marketing/index.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="../../index.html@p=62.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="en_GB" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Marketing – Innoledge" />
 		<meta property="og:description" content="Sourcing is an in demand business, we have sourced products for many companies in many countries – we can assist you with various tasks." />

--- a/services/regulatory-affairs/index.html
+++ b/services/regulatory-affairs/index.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="../../index.html@p=65.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="en_GB" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Regulatory Affairs – Innoledge" />
 		<meta property="og:description" content="The needs of registrations and licenses can be seen as laborious and time consuming hurdles but it is also a useful protection to invest in business development." />

--- a/services/sourcing/index.html
+++ b/services/sourcing/index.html
@@ -14,7 +14,7 @@
 		<link rel="canonical" href="../../index.html@p=63.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="en_GB" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="article" />
 		<meta property="og:title" content="Sourcing – Innoledge" />
 		<meta property="og:description" content="Sourcing is an in demand business, we have sourced products for many companies in many countries – we can assist you with various tasks." />

--- a/zh/service/index.html
+++ b/zh/service/index.html
@@ -13,7 +13,7 @@
 		<link rel="canonical" href="index.html" />
 		<meta name="generator" content="All in One SEO (AIOSEO) 4.2.5.1 " />
 		<meta property="og:locale" content="zh_HK" />
-		<meta property="og:site_name" content="Innoledge – Just another WordPress site" />
+		<meta property="og:site_name" content="Innoledge" />
 		<meta property="og:type" content="website" />
 		<meta property="og:title" content="Services – Innoledge" />
 		<meta property="og:url" content="https://innoledge.com/zh/service/" />


### PR DESCRIPTION
## Summary
- update all HTML pages' `og:site_name` meta tags to use `Innoledge` instead of the default WordPress tagline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844bdfc0d38832a97bd141d3bee6bd4