### PR TITLE
Fix accordion plugin comment

### DIFF
--- a/wp-content/plugins/plethora-tabs-accordions/js/accordion.jquery-plugin.js@ver=1.0
+++ b/wp-content/plugins/plethora-tabs-accordions/js/accordion.jquery-plugin.js@ver=1.0
@@ -72,7 +72,7 @@
 				item.accordionAncestorItems.push(uuid);
 			});
 
-			// If this item has `initially-open prop` set to true, open it
+                        // If this item has the `initially-open` prop set to true, open it
 			if (settings.initiallyOpen) {
 				/**
 				 * We aren't opening the item here (only setting open attributes)


### PR DESCRIPTION
## Summary
- correct comment for initially-open property in accordion plugin

## Testing
- `git diff -U0 wp-content/plugins/plethora-tabs-accordions/js/accordion.jquery-plugin.js@ver=1.0`

------
https://chatgpt.com/codex/tasks/task_e_6844be174904832a8c2d97bccb805d8c